### PR TITLE
Add the ability to have ember-try be just a boolean

### DIFF
--- a/src/providers/github/templates/v2-addon/ember-try.js
+++ b/src/providers/github/templates/v2-addon/ember-try.js
@@ -1,0 +1,22 @@
+import path from 'path';
+
+/**
+ * @typedef {import('types').GitHubV2AddonConfig} Config
+ *
+ * @param {import('types').GitHubV2AddonConfig} config;
+ * @param {import('types').Options} options
+ */
+export async function getEmberTryNames(config, options) {
+  let { testApp } = config;
+
+  let testAppPath = path.join(options.cwd, testApp);
+
+  let emberTryPath = path.join(testAppPath, 'config', 'ember-try.js');
+
+  let module = await import(emberTryPath);
+  let emberTry = await module.default();
+
+  let scenarios = emberTry.scenarios.map((scenario) => scenario.name);
+
+  return scenarios;
+}

--- a/src/providers/github/templates/v2-addon/index.js
+++ b/src/providers/github/templates/v2-addon/index.js
@@ -6,6 +6,7 @@ import { stripIndent } from 'common-tags';
 import yaml from 'js-yaml';
 
 import { verifyConfig } from './config.js';
+import { getEmberTryNames } from './ember-try.js';
 
 const targetFile = '.github/workflows/ci.yml';
 
@@ -200,6 +201,19 @@ async function buildCi(config, options) {
   }
 
   if (support?.['ember-try']) {
+    let scenarios = [];
+
+    if (support['ember-try'] === true) {
+      scenarios = await getEmberTryNames(config, options);
+    } else if (Array.isArray(support['ember-try'])) {
+      scenarios = support['ember-try'];
+    } else {
+      assert(
+        false,
+        'Unknown value type for support.ember-try. Expected an array of scenario names or `true`.'
+      );
+    }
+
     tryScenarios = {
       'try-scenarios': {
         name: '${{ matrix.ember-try-scenario }}',
@@ -209,7 +223,7 @@ async function buildCi(config, options) {
         strategy: {
           'fail-fast': true,
           matrix: {
-            'ember-try-scenario': config.support['ember-try'],
+            'ember-try-scenario': scenarios,
           },
         },
         steps: [


### PR DESCRIPTION
This tells ember-ci-update to read your ember-try config so that you don't need to manually maintain a list in 2 places at once.