### PR TITLE
Use native YAML for generating for the GH Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ CLI to generate robust CI configs for ember projects
 ## Setup
 
 - Must have Node 16+
+- pnpm only.
+  yarn and npm are not supported.
 
 ## Usage
 
@@ -40,6 +42,8 @@ testApp: './testing/ember-app'
 
 lint:
   commits: true
+  cmd: pnpm lint
+  # or optionally specific paths:
   eslint:
     - "./ember-resources"
     - "./testing/ember-app"
@@ -72,20 +76,6 @@ support:
 
   # reads the config/ember-try.js config file
   ember-try: true
-
-  # specify specific entries. must be a subset of config/ember-try.js
-  ember-try:
-    - ember-3.25
-    - ember-3.26
-    - ember-3.28
-    - ember-4.0.0
-    - ember-4.4
-    - ember-concurrency-v1
-    - ember-release
-    - ember-beta
-    - ember-canary
-    - embroider-safe
-    - embroider-optimized
 
 # Optional, default is to not use semantic-release
 release:

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
   "dependencies": {
     "chai": "^4.3.6",
     "common-tags": "^1.8.2",
+    "ejs": "^3.1.8",
     "execa": "^6.1.0",
     "fs-extra": "^10.1.0",
     "js-yaml": "^4.1.0",
+    "klaw": "^4.0.1",
     "yaml": "^2.1.1"
   },
   "packageManager": "pnpm@7.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,18 +6,22 @@ specifiers:
   '@types/node': ^17.0.36
   chai: ^4.3.6
   common-tags: ^1.8.2
+  ejs: ^3.1.8
   execa: ^6.1.0
   fs-extra: ^10.1.0
   js-yaml: ^4.1.0
+  klaw: ^4.0.1
   typescript: ^4.7.2
   yaml: ^2.1.1
 
 dependencies:
   chai: 4.3.6
   common-tags: 1.8.2
+  ejs: 3.1.8
   execa: 6.1.0
   fs-extra: 10.1.0
   js-yaml: 4.1.0
+  klaw: 4.0.1
   yaml: 2.1.1
 
 devDependencies:
@@ -444,7 +448,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: true
 
   /argparse/1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -491,6 +494,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /async/3.2.4:
+    resolution: {integrity: sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==}
+    dev: false
+
   /babel-eslint/10.1.0_eslint@7.32.0:
     resolution: {integrity: sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==}
     engines: {node: '>=6'}
@@ -511,14 +518,18 @@ packages:
 
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: true
 
   /brace-expansion/1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-    dev: true
+
+  /brace-expansion/2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+    dependencies:
+      balanced-match: 1.0.2
+    dev: false
 
   /braces/3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
@@ -567,7 +578,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-    dev: true
 
   /check-error/1.0.2:
     resolution: {integrity: sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==}
@@ -584,7 +594,6 @@ packages:
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: true
 
   /color-name/1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
@@ -592,7 +601,6 @@ packages:
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: true
 
   /common-tags/1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
@@ -601,7 +609,6 @@ packages:
 
   /concat-map/0.0.1:
     resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
-    dev: true
 
   /cross-spawn/7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
@@ -699,6 +706,14 @@ packages:
       no-case: 3.0.4
       tslib: 2.4.0
     dev: true
+
+  /ejs/3.1.8:
+    resolution: {integrity: sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+    dependencies:
+      jake: 10.8.5
+    dev: false
 
   /ember-rfc176-data/0.3.17:
     resolution: {integrity: sha512-EVzTTKqxv9FZbEh6Ktw56YyWRAA0MijKvl7H8C06wVF+8f/cRRz3dXxa4nkwjzyVwx4rzKGuIGq77hxJAQhWWw==}
@@ -1130,6 +1145,12 @@ packages:
       flat-cache: 3.0.4
     dev: true
 
+  /filelist/1.0.4:
+    resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
+    dependencies:
+      minimatch: 5.1.0
+    dev: false
+
   /fill-range/7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
     engines: {node: '>=8'}
@@ -1274,7 +1295,6 @@ packages:
   /has-flag/4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /has-property-descriptors/1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
@@ -1457,6 +1477,17 @@ packages:
   /isexe/2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  /jake/10.8.5:
+    resolution: {integrity: sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      async: 3.2.4
+      chalk: 4.1.2
+      filelist: 1.0.4
+      minimatch: 3.1.2
+    dev: false
+
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
     dev: true
@@ -1511,6 +1542,11 @@ packages:
       universalify: 2.0.0
     optionalDependencies:
       graceful-fs: 4.2.10
+    dev: false
+
+  /klaw/4.0.1:
+    resolution: {integrity: sha512-pgsE40/SvC7st04AHiISNewaIMUbY5V/K8b21ekiPiFoYs/EYSdsGa+FJArB1d441uq4Q8zZyIxvAzkGNlBdRw==}
+    engines: {node: '>=14.14.0'}
     dev: false
 
   /levn/0.4.1:
@@ -1594,7 +1630,13 @@ packages:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
-    dev: true
+
+  /minimatch/5.1.0:
+    resolution: {integrity: sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==}
+    engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
 
   /minimist/1.2.6:
     resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
@@ -1958,7 +2000,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
-    dev: true
 
   /supports-preserve-symlinks-flag/1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}

--- a/src/providers/github/templates/v2-addon/files/actions/assert-build/action.yml.ejs
+++ b/src/providers/github/templates/v2-addon/files/actions/assert-build/action.yml.ejs
@@ -1,0 +1,23 @@
+name: Build and Assert Assets Exists
+description: Build the package and assert that file contents exist as we expect
+runs:
+  using: "composite"
+  steps:
+  - name: Build and Assert Output
+    shell: bash
+    run: |-
+      echo '
+        target: ${{ env.dist }}
+        setup:
+          run: <%= build.run %>
+          cwd: <%= addon %>
+        expect: |
+<%= utils.eachLine(build.expect, line => utils.indent(5) + line) %>
+      ' >> assert-contents.config.yml
+      npx assert-folder-contents
+
+  - name: Upload dist assets to cache
+    uses: actions/upload-artifact@v3
+    with:
+      name: dist
+      path: ${{ env.dist }}

--- a/src/providers/github/templates/v2-addon/files/actions/download-built-package/action.yml
+++ b/src/providers/github/templates/v2-addon/files/actions/download-built-package/action.yml
@@ -1,0 +1,10 @@
+name: Download built package from cache
+description: Download built package from cache
+runs:
+  using: "composite"
+  steps:
+  - name: Download built package from cache
+    uses: actions/download-artifact@v3
+    with:
+      name: dist
+      path: ${{ env.dist }}

--- a/src/providers/github/templates/v2-addon/files/actions/pnpm/action.yml
+++ b/src/providers/github/templates/v2-addon/files/actions/pnpm/action.yml
@@ -1,0 +1,17 @@
+name: Setup node and pnpm
+description: Setup node and install dependencies using pnpm
+runs:
+  using: "composite"
+  steps:
+    - uses: volta-cli/action@v1
+    - name: Cache pnpm modules
+      uses: actions/cache@v3
+      with:
+        path: ~/.pnpm-store
+        key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-
+    - uses: pnpm/action-setup@v2.2.2
+      with:
+        version: 7.11.0
+        run_install: true

--- a/src/providers/github/templates/v2-addon/files/workflows/ci.yml.ejs
+++ b/src/providers/github/templates/v2-addon/files/workflows/ci.yml.ejs
@@ -1,0 +1,201 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request: {}
+
+concurrency:
+   group: ci-${{ github.head_ref || github.ref }}
+   cancel-in-progress: true
+
+env:
+  CI: true
+  dist: <%- env.dist %>
+
+jobs:
+  install_dependencies:
+    name: Install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pnpm
+
+<% if (lint?.eslint) { %>
+  eslint:
+    name: ESLint {{ matrix.path }}
+    runs-on: ubuntu-latest
+    needs: [install_dependencies]
+    strategy:
+      fail-fast: true
+      matrix:
+        path:
+<%- utils.toMultiLineArray(lint.eslint, 5) %>
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pnpm
+      - name: Lint
+        run: pnpm eslint .
+        working-directory: ${{ matrix.path }}
+<% } %>
+
+<% if (lint?.cmd) { %>
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: [install_dependencies]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pnpm
+      - name: Lint
+        run: <%= lint.cmd %>
+<% } %>
+
+<% if (lint?.commits) { %>
+  commits:
+    name: Commit Messages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: volta-cli/action@v1
+      - uses: wagoid/commitlint-github-action@v4.1.9
+        with:
+          configFile: 'commitlint.config.cjs'
+<% } %>
+
+  build:
+    name: Build Tests
+    needs: [install_dependencies]
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pnpm
+      - uses: ./.github/actions/assert-build
+
+<% if (support?.typescript) { %>
+  typecheck:
+    name: '${{ matrix.typescript-scenario }}'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    needs: [build]
+    continue-on-error: true
+    strategy:
+      fail-fast: true
+      matrix:
+        typescript-scenario:
+<%- utils.toMultiLineArray(support.typescript, 5) %>
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pnpm
+      - uses: ./.github/actions/download-built-package
+      - name: 'Change TS to ${{ matrix.typescript-scenario }}'
+        run: 'pnpm add --save-dev ${{ matrix.typescript-scenario}}'
+        working-directory: <%= testApp %>
+      - name: 'Type checking'
+      <% if (support?.glint) { %>
+        run: |
+          pnpm --filter <%= testAppName %> exec tsc -v;
+          pnpm --filter <%= testAppName %> exec glint --version;
+          pnpm --filter <%= testAppName %> exec glint;
+      <% } else { %>
+          pnpm --filter <%= testAppName %> exec tsc -v;
+          pnpm --filter <%= testAppName %> exec tsc --build;
+      <% } %>
+
+  <% } %>
+
+
+  default_tests:
+    name: Default Tests
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pnpm
+      - uses: ./.github/actions/download-built-package
+      - run: pnpm --filter <%= testAppName %> test:ember
+
+  floating_tests:
+    name: Floating Deps Test
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pnpm
+      - name: Install Dependencies (without lockfile)
+        run: rm pnpm-lock.yaml && pnpm install
+      - uses: ./.github/actions/download-built-package
+      - run: pnpm --filter <%= testAppName %> test:ember
+
+<% if (support?.['ember-try']) { %>
+  try_scenarios:
+    name: ${{ matrix.try-scenario }}
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    needs: [default_tests]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        try-scenario:
+<%- utils.toMultiLineArray(tryScenarios, 5) %>
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pnpm
+      - uses: ./.github/actions/download-built-package
+      - name: Run Tests
+        working-directory: <%= testApp %>
+        run: >-
+          node_modules/.bin/ember try:one ${{ matrix.try-scenario }}
+          --skip-cleanup
+
+<% } %>
+
+<% if (release?.semantic) { %>
+  release:
+    name: Release
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    needs:
+<%- utils.toMultiLineArray(releaseRequirements, 3) %>
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: volta-cli/action@v3
+      - uses: ./.github/actions/pnpm
+      - uses: ./.github/actions/download-built-package
+      - name: Release
+        run: ./node_modules/.bin/semantic-release
+        working-directory: ./ember-resources
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+<% } %>
+
+<% for (let extraJob of extra) { %>
+  <%= extraJob.id %>:
+    name: <%= extraJob.name %>
+    runs-on: ubuntu-latest
+    needs: <%= extraJob.needs %>
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: volta-cli/action@v3
+      - uses: ./.github/actions/pnpm
+      - uses: ./.github/actions/download-built-package
+<%= extraJob.steps %>
+
+<% } %>

--- a/src/providers/github/templates/v2-addon/index.js
+++ b/src/providers/github/templates/v2-addon/index.js
@@ -1,25 +1,47 @@
-import assert from 'assert';
-import path from 'path';
-import fse from 'fs-extra';
-import { stripIndent } from 'common-tags';
+import assert from 'node:assert';
+import path, { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
+import fse from 'fs-extra';
+import klaw from 'klaw';
 import yaml from 'js-yaml';
+import ejs from 'ejs';
 
 import { verifyConfig } from './config.js';
 import { getEmberTryNames } from './ember-try.js';
 
 const targetFile = '.github/workflows/ci.yml';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const templateFiles = path.join(__dirname, 'files');
+
+const stringify = (x) => `"${x}"`;
+const toYamlArray = (array) => `[${array.map(stringify).join(', ')}]`;
+const indent = (num) => {
+  let result = '';
+
+  for (let i = 0; i < num; i++) {
+    result += '  ';
+  }
+
+  return result;
+};
+const toMultiLineArray = (array, indentCount) => {
+  return array
+    .map((item) => `- ${item}`)
+    .map((line) => indent(indentCount) + line)
+    .join('\n');
+};
+const eachLine = (str, callback) => {
+  return str.split('\n').map(callback).join('\n');
+}
+
 /**
  * @param {import('types').GitHubConfig} config
  * @param {import('types').Options} options
  */
 export default async function v2Addon(config, options) {
-  let _config = verifyConfig(config);
-
-  let ci = await buildCi(_config, options);
-
-  await write(ci, options);
+  await buildCi(verifyConfig(config), options);
 }
 
 /**
@@ -36,91 +58,16 @@ async function write(ci, options) {
 }
 
 /**
- * TODO: determine what version "latest" is
- */
-const actions = {
-  pnpm: 'pnpm/action-setup@v2.2.2',
-  cache: 'actions/cache@v3',
-  checkout: 'actions/checkout@v3',
-  downloadArtifact: 'actions/download-artifact@v3',
-  uploadArtifact: 'actions/upload-artifact@v3',
-  volta: 'volta-cli/action@v1',
-  commitlint: 'wagoid/commitlint-github-action@v5.0.2',
-};
-
-let init = [{ uses: actions.checkout }, { uses: actions.volta }];
-
-let depCache = [
-  {
-    name: 'Cache pnpm modules',
-    uses: actions.cache,
-    with: {
-      path: '~/.pnpm-store',
-      key: `\${{ runner.os }}-\${{ hashFiles('**/pnpm-lock.yaml') }}`,
-      'restore-keys': '${{ runner.os }}-',
-    },
-  },
-];
-
-let pnpm = [
-  {
-    uses: actions.pnpm,
-    with: {
-      /**
-       * TODO: detect pnpm version based on package.json
-       *       information
-       */
-      version: '7.1.2',
-    },
-  },
-];
-
-let getDist = [
-  {
-    name: 'Download built package from cache',
-    uses: actions.downloadArtifact,
-    with: {
-      name: 'dist',
-      path: '${{ env.dist }}',
-    },
-  },
-];
-
-/**
  * @typedef {import('types').GitHubV2AddonConfig} Config
  *
  * @param {import('types').GitHubV2AddonConfig} config;
  * @param {import('types').Options} options
  */
 async function buildCi(config, options) {
-  let eslint = {};
-  let typescript = {};
-  let tryScenarios = {};
-  let publish = {};
-  let extras = {};
-
-  let {
-    defaultBranch = 'main',
-    // packageManager = 'pnpm',
-    addon,
-    testApp,
-    build,
-    support,
-    release,
-    extra,
-  } = config;
-
-  let system = {
-    'timeout-minutes': 5,
-    'runs-on': 'ubuntu-latest',
-  };
+  let { defaultBranch = 'main', addon, support, release, extra } = config;
 
   let libraryName = await verifyAddon(config, options);
   let testAppName = await verifyTestApp(config, options, libraryName);
-
-  let onlyPR = {
-    if: `github.ref != 'refs/heads/${defaultBranch}'`,
-  };
 
   let env = {
     CI: true,
@@ -130,85 +77,12 @@ async function buildCi(config, options) {
     dist: path.join(addon, 'dist'),
   };
 
-  let install = [{ name: 'Install Dependencies', run: 'pnpm install' }];
-  let installNoLockfile = [
-    { name: 'Install Dependencies (without lockfile)', run: 'rm pnpm-lock.yaml && pnpm install' },
-  ];
-  let installNoFrozen = [
-    {
-      name: 'Install Dependencies (without frozen lockfile)',
-      run: 'pnpm install --no-frozen-lockfile',
-    },
-  ];
-
   if (config.lint?.eslint) {
     await verifyEslint(config, options);
-
-    eslint = {
-      eslint: {
-        name: 'ESLint',
-        needs: ['install_dependencies'],
-        ...system,
-        strategy: {
-          'fail-fast': true,
-          matrix: {
-            path: [...config.lint.eslint],
-          },
-        },
-        steps: [
-          ...init,
-          ...depCache,
-          ...pnpm,
-          ...install,
-          {
-            name: 'ESLint',
-            run: 'cd ${{ matrix.path }} && pnpm run lint:js',
-          },
-        ],
-      },
-    };
   }
 
   if (config.support?.typescript) {
     assert(Array.isArray(config.support.typescript), 'expected support.typescript to be an array');
-
-    let isGlint = config.support?.glint ?? false;
-
-    let buildCommand = isGlint ? `glint` : 'tsc --build';
-
-    typescript = {
-      'typescript-compatibility': {
-        name: '${{ matrix.typescript-scenario }}',
-        ...system,
-        'continue-on-error': true,
-        needs: ['build'],
-        strategy: {
-          'fail-fast': true,
-          matrix: {
-            'typescript-scenario': config.support.typescript,
-          },
-        },
-        steps: [
-          ...init,
-          ...depCache,
-          ...pnpm,
-          ...installNoFrozen,
-          ...getDist,
-          {
-            name: 'Update TS Version',
-            run: 'pnpm add --save-dev ${{ matrix.typescript-scenario }}',
-            'working-directory': testApp,
-          },
-          {
-            name: 'Type checking',
-            run:
-              `pnpm --filter ${testAppName} exec tsc -v; ` +
-              (isGlint ? `pnpm --filter ${testAppName} exec glint --version; ` : '') +
-              `pnpm --filter ${testAppName} exec ${buildCommand}`,
-          },
-        ],
-      },
-    };
   }
 
   if (support?.['ember-try']) {
@@ -216,198 +90,77 @@ async function buildCi(config, options) {
 
     if (support['ember-try'] === true) {
       scenarios = await getEmberTryNames(config, options);
-    } else if (Array.isArray(support['ember-try'])) {
-      scenarios = support['ember-try'];
-    } else {
-      assert(
-        false,
-        'Unknown value type for support.ember-try. Expected an array of scenario names or `true`.'
-      );
     }
 
-    tryScenarios = {
-      'try-scenarios': {
-        name: '${{ matrix.ember-try-scenario }}',
-        ...system,
-        'timeout-minutes': 10,
-        needs: ['tests'],
-        strategy: {
-          'fail-fast': true,
-          matrix: {
-            'ember-try-scenario': scenarios,
-          },
-        },
-        steps: [
-          ...init,
-          ...depCache,
-          ...pnpm,
-          ...installNoLockfile,
-          ...getDist,
-          {
-            name: 'test',
-            'working-directory': testApp,
-            run: `node_modules/.bin/ember try:one \${{ matrix.ember-try-scenario }} --skip-cleanup`,
-          },
-        ],
-      },
-    };
+    config.tryScenarios = scenarios;
   }
 
   if (release?.semantic) {
-    publish = {
-      release: {
-        name: 'Release',
-        ...system,
-        if: `github.ref == 'refs/heads/${defaultBranch}'`,
-        needs: [
-          'tests',
-          ...(Object.keys(typescript).length ? ['typescript-compatibility'] : []),
-          ...(Object.keys(tryScenarios).length ? ['try-scenarios'] : []),
-          'floating-deps-tests',
-        ],
-        steps: [
-          { uses: actions.checkout, with: { 'persist-credentials': false } },
-          { uses: actions.volta },
-          ...depCache,
-          ...pnpm,
-          ...install,
-          ...getDist,
-          {
-            name: 'Release',
-            run: './node_modules/.bin/semantic-release',
-            'working-directory': addon,
-            env: {
-              NPM_TOKEN: '${{ secrets.NPM_TOKEN }}',
-              GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}',
-            },
-          },
-        ],
-      },
-    };
+    /**
+     * Names of jobs in ci.yml
+     */
+    config.releaseRequirements = [
+      'default_tests',
+      'floating_tests',
+      ...(Object.keys(config.support?.typescript || {}).length ? ['typecheck'] : []),
+      ...(config.support?.['ember-try'] ? ['try_scenarios'] : []),
+    ];
   }
+
+  config.extra = [];
 
   if (extra) {
     assert(Array.isArray(extra), 'Expected extra entry to be an array');
 
     for (let extraJob of extra) {
-      let builtExtra = {
+      config.extra.push({
         ...extraJob,
-        ...system,
-        steps: [...init, ...depCache, ...pnpm, ...install, ...getDist, ...extraJob.steps],
-      };
-
-      let id =
-        builtExtra.id ||
-        (builtExtra.name ?? `extra_${extra.indexOf(extraJob)}`)
-          .split('')
-          .filter((char) => char.match(/\S/))
-          .join('');
-
-      extras[id] = builtExtra;
+        id:
+          extraJob.id ||
+          (extraJob.name ?? `extra_${extra.indexOf(extraJob)}`)
+            .split('')
+            .filter((char) => char.match(/\S/))
+            .join(''),
+        steps: extraJob.steps.map((step) => indent(4)).join('\n'),
+      });
     }
   }
 
-  let assertContents = yaml.dump({
-    target: env.dist,
-    setup: { run: build.run, cwd: addon },
-    expect: build.expect,
-  });
+  for await (const file of klaw(templateFiles)) {
+    if (file.stats.isDirectory()) continue;
 
-  let ci = {
-    name: 'CI',
-    on: {
-      pull_request: null,
-      push: {
-        branches: [defaultBranch],
-      },
-      schedule: [
-        // every Sunday at 3am
-        { cron: '0 3 * * 0 ' },
-      ],
-    },
+    let relative = path.relative(templateFiles, file.path);
+    let destination = path.join(options.cwd, '.github', relative.replace(/\.ejs$/, ''));
+    let destinationDir = path.dirname(destination);
 
-    env,
+    await fse.mkdirp(destinationDir);
 
-    jobs: {
-      install_dependencies: {
-        name: 'Install Dependencies',
-        ...system,
-        steps: [...init, ...depCache, ...pnpm, ...install],
-      },
-      ...eslint,
-      ...(config.lint?.commits
-        ? {
-            commits: {
-              name: 'Commit Messages',
-              ...system,
-              steps: [
-                {
-                  uses: actions.checkout,
-                  with: { 'fetch-depth': 0 },
-                },
-                { uses: actions.volta },
-                { uses: actions.commitlint },
-              ],
-            },
-          }
-        : {}),
-      build: {
-        name: 'Build Tests',
-        needs: ['install_dependencies'],
-        ...system,
-        steps: [
-          ...init,
-          ...depCache,
-          ...pnpm,
-          ...install,
-          {
-            name: 'Build and Assert Output',
-            run: stripIndent`
-              echo '${assertContents}' >> assert-contents.config.yml
-              npx assert-folder-contents
-            `,
-          },
-          {
-            uses: actions.uploadArtifact,
-            with: { name: 'dist', path: '${{ env.dist }}' },
-          },
-        ],
-      },
+    console.info(`Processing ${relative}`);
 
-      tests: {
-        name: 'Default Tests',
-        ...system,
-        needs: ['build'],
-        steps: [
-          ...init,
-          ...depCache,
-          ...pnpm,
-          ...install,
-          ...getDist,
-          { run: `pnpm --filter ${testAppName} run test:ember` },
-        ],
-      },
-      'floating-deps-tests': {
-        name: 'Floating Deps Test',
-        ...system,
-        needs: ['build'],
-        steps: [
-          ...init,
-          ...depCache,
-          ...pnpm,
-          ...installNoLockfile,
-          ...getDist,
-          { run: `pnpm --filter ${testAppName} run test:ember` },
-        ],
-      },
-      ...tryScenarios,
-      ...typescript,
-      ...publish,
-      ...extras,
-    },
-  };
+    if (file.path.endsWith('.ejs')) {
+      let templateContent = await fse.readFile(file.path);
+      let content = ejs.render(templateContent.toString(), {
+        ...config,
+        env,
+        defaultBranch,
+        libraryName,
+        testAppName,
+        utils: {
+          toArray: toYamlArray,
+          toMultiLineArray,
+          stringify,
+          indent,
+          eachLine,
+        },
+      });
 
-  return ci;
+      await fse.writeFile(destination, content);
+      continue;
+    }
+
+    // Copy to destination
+    await fse.copyFile(file.path, destination);
+  }
 }
 
 /**


### PR DESCRIPTION
Tested here: https://github.com/NullVoxPopuli/ember-resources/pull/633

The goal of these changes is to make it more approchable to forget about the ci-update tool and manage the ci configs yourself.

BREAKING CHANGE:
 - ember-try option now _only_ supports a value of `true` -- It willl always read from the ember-try.js config.
 - only pnpm is supported
